### PR TITLE
bluetooth: Fix for failure when starting service

### DIFF
--- a/recipes-connectivity/bluetooth/service_file/bluetooth_rk.service
+++ b/recipes-connectivity/bluetooth/service_file/bluetooth_rk.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=Bluetooth hciattach service
+Before=bluetooth.service
+After=dev-ttyS0.device
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/rtk_hciattach -n -s 115200 ttyS0 rtk_h5
-Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The Realtek RTL8723BS (and also RTL8723DS) chipset is a SDIO wifi chip.
It contains a Bluetooth module which is connected via UART to the host.

Realtek's userspace tool (rtk_hciattach) needs ttyS0
to complete the initialization.

Signed-off-by: Vicentiu Galanopulo <vicentiu@resin.io>